### PR TITLE
Token swap search

### DIFF
--- a/src/contexts/kaspa/KaspaProvider.tsx
+++ b/src/contexts/kaspa/KaspaProvider.tsx
@@ -88,7 +88,6 @@ export function KaspaProvider({ children }: { children: ReactNode }) {
         } else {
           entry.reject('Service worker disconnected')
         }
-        
       }
     })
     connectionRef.current = connection
@@ -156,4 +155,3 @@ export function KaspaProvider({ children }: { children: ReactNode }) {
     <KaspaContext.Provider value={{ load: reloadState, kaspa, request }}>{children}</KaspaContext.Provider>
   )
 }
-

--- a/src/pages/Wallet/Swap/SwapTokenSelect.tsx
+++ b/src/pages/Wallet/Swap/SwapTokenSelect.tsx
@@ -11,48 +11,18 @@ interface SwapTokenSelectProps {
   onClose: () => void
 }
 
-const SwapTokenSelect: React.FC<SwapTokenSelectProps> = ({ tokens, onSelectToken, onClose }) => {
-  // if tokens are undefined just set it to an empty array to make this easier
-  // This seems like it shouldn't ever be undefined. It's confusing why it can be, instead of just an empty array?
-  if (tokens == undefined) {
-    tokens = []
-  }
-
-  // Search term will be in upper
+const SwapTokenSelect: React.FC<SwapTokenSelectProps> = ({ tokens = [], onSelectToken, onClose }) => {
   const [searchTerm, setSearchTerm] = useState<string>('')
   const [filteredTokens, setFilteredTokens] = useState<ChaingeToken[]>(tokens)
 
   const handleSearch = (_searchTerm: string) => {
-    const upperSearchTerm = _searchTerm.toUpperCase().trim()
-
-    const filterSearch = (token: ChaingeToken) => {
-      // If the token is CUSDT then we want to use the contract address, Otherwise we use the symbol.
-      const isCusdt = token.contractAddress === 'CUSDT'
-
-      let tick: string
-
-      // I was expecting `tick` to be here like the other tokens. But I guess contractAddress works?
-      if (isCusdt) {
-        tick = token.contractAddress
-      } else {
-        tick = token.symbol
-      }
-
-      const upperTick = tick.toUpperCase()
-
-      return upperTick.includes(upperSearchTerm)
-    }
-
-    setSearchTerm(upperSearchTerm)
-
-    // if search term is empty, set the filtered tokens list to be the original list
-    if (upperSearchTerm === '') {
-      setFilteredTokens(tokens)
-      return
-    } else {
-      const filtered = tokens.filter(filterSearch)
-      setFilteredTokens(filtered)
-    }
+    setSearchTerm(_searchTerm)
+    const filtered = tokens.filter(
+      (token) =>
+        token.symbol.toLowerCase().includes(_searchTerm.toLowerCase()) ||
+        token.contractAddress.toLowerCase().includes(_searchTerm.toLowerCase()),
+    )
+    setFilteredTokens(filtered)
   }
 
   return (
@@ -73,7 +43,7 @@ const SwapTokenSelect: React.FC<SwapTokenSelectProps> = ({ tokens, onSelectToken
         </ul>
       ) : (
         <p className="text-mutedtext text-base text-center">
-          {searchTerm + ' is not supported for swapping in Ghost Wallet'}
+          {searchTerm.toUpperCase() + ' is not supported for swapping in Ghost Wallet'}
         </p>
       )}
 


### PR DESCRIPTION
- [x] Add search bar for token swap list
- [x] Removes top bar and close button
- [x] Adds close button to the bottom
- [x] Add better error message for empty searches. 

As for the error message, Does it matter if it's in the wallet or not? Can coins that are not in the wallet be listed here? If so the error message doesn't make sense but it works fine as a placeholder.

![image](https://github.com/user-attachments/assets/c9047a7b-2cde-4d56-8223-663c7b771f32)
![image](https://github.com/user-attachments/assets/ee2146c9-6d82-4fd5-a566-a7ae78cc603d)
